### PR TITLE
Fix insurance certificate premium details display

### DIFF
--- a/diagrams/MCP_INTEGRATION_WRITEUP.md
+++ b/diagrams/MCP_INTEGRATION_WRITEUP.md
@@ -182,32 +182,24 @@ The certificate generation demonstrates the full power of the MCP integration:
    # Action: generate_certificate
    ```
 
-2. **Policy Data Generation**
+2. **Parameter Validation**
    ```python
-   # Generate unique policy identifiers
-   policy_id = f"POL-{uuid.uuid4().hex[:8].upper()}"
-   farmer_id = f"FID-{uuid.uuid4().hex[:6].upper()}"
-   
-   # Calculate insurance values
-   base_premium_per_hectare = 15000
-   total_sum_insured = area_hectare * base_premium_per_hectare * 3
+   # Validate required parameters
+   if not all([farmer_name, crop, area_hectare, state]):
+       raise ValueError("Missing required parameters")
    ```
 
 3. **MCP Certificate Generation**
    ```python
-   # Prepare comprehensive certificate data
+   # Prepare simplified certificate data
    certificate_payload = {
        "name": "generate_insurance_certificate",
        "arguments": {
-           "policy_id": policy_id,
            "farmer_name": farmer_name,
-           "crop_details": {
-               "name": crop,
-               "area_hectare": area_hectare,
-               "premium_paid_by_farmer": farmer_premium,
-               "premium_paid_by_govt": government_premium
-           },
-           "terms_and_conditions": [...]
+           "state": state,
+           "area_hectare": area_hectare,
+           "crop": crop,
+           "disease": disease
        }
    }
    ```

--- a/fsm_agent/core/nodes/insurance_node.py
+++ b/fsm_agent/core/nodes/insurance_node.py
@@ -569,8 +569,12 @@ Respond with ONLY a JSON object:
                     message += f"**Policy ID:** {policy_id}\n"
                     message += f"**Coverage Area:** {result.get('area_hectare', 'N/A')} hectares\n"
                     
+                    # Include premium details if available
+                    if result.get("premium_details"):
+                        message += f"\n**Premium Details:**\n{result['premium_details']}"
+                    
                     if result.get("pdf_generated"):
-                        message += f"\n📄 **Your insurance certificate PDF has been generated and is ready for download.**"
+                        message += f"\n\n📄 **Your insurance certificate PDF has been generated and is ready for download.**"
                         if result.get("certificate_details"):
                             message += f"\n\n**Certificate Details:**\n{result['certificate_details']}"
                     else:


### PR DESCRIPTION
- Update insurance tool to always include premium_details in certificate response
- Extract premium details from both text and resource MCP responses
- Add fallback message when premium details not found
- Simplify insurance node response formatting to use premium_details field
- Update MCP integration documentation to reflect simplified approach
- Ensure app compatibility by providing expected premium_details field

Fixes issue where certificate generation wasn't showing premium details like the premium calculation response, affecting app quick view display.